### PR TITLE
At least load amsmath and xcolor in LLNCS

### DIFF
--- a/llncs.tex
+++ b/llncs.tex
@@ -2,8 +2,10 @@
 % LLNCS macro package for Springer Computer Science proceedings;
 % Version 2.20 of 2017/10/04
 %
+\RequirePackage[dvipsnames,table,prologue]{xcolor}
 \documentclass[runningheads]{llncs}
 %
+\usepackage{amsmath}
 \usepackage{graphicx}
 % Used for displaying a sample figure. If possible, figure files should
 % be included in EPS format.


### PR DESCRIPTION
Since amsmath and xcolor are packages loaded by default in ACM but not in LLNCS one may run into build trouble when using anything from these packages because ACM will work smoothly while LLNCS simply fails.